### PR TITLE
fixed issue of missing .empty() when exiting page

### DIFF
--- a/angular-datepicker-light.js
+++ b/angular-datepicker-light.js
@@ -164,8 +164,7 @@
 
             // cleanup on destroy
             scope.$on('$destroy', function () {
-                ctrl.empty();
-                ctrl.container.remove();
+                ctrl = {};
             });
 
             function _documentKeyDown(e) {


### PR DESCRIPTION
fixed issue of missing .empty() when exiting page  and ondestroy method tries to remove object.

Despite having jquery, I found when leaving one angular view for another, as the object was destroyed that the ondestroy method failed. Please consider this pull request, as it fixes the issue I had, and seems simpler if the goal is to destroy the object - remove a further dependency on jquery.